### PR TITLE
Persist window state

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start": "electron .",
     "prebuild": "sudo rm -rf dist",
     "build": "sudo electron-builder",
+    "build:commit": "npm run build -- --config.extraMetadata.version=$(git rev-parse --short HEAD)",
     "postbuild": "electron-builder install-app-deps",
     "postinstall": "run-s postbuild",
     "test": "run-s lint",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@trodi/electron-splashscreen": "^0.3.4",
     "dom-loaded": "^1.0.1",
     "electron-is-dev": "^1.0.1",
+    "electron-window-state": "^5.0.3",
     "mpris-service": "^2.0.0",
     "select-dom": "^4.1.3"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const path = require(`path`);
 const { ipcMain, shell, app } = require(`electron`);
 const isDev = require(`electron-is-dev`);
 const { initSplashScreen } = require(`@trodi/electron-splashscreen`);
+const getWindowState = require(`electron-window-state`);
 
 const POCKET_CASTS_URL = `https://playbeta.pocketcasts.com/web/`;
 
@@ -14,10 +15,18 @@ try {
 let window;
 
 const createWindow = () => {
-  const size = { width: 1200, height: 800 };
+  const windowState = getWindowState({
+    defaultWidth: 1200,
+    defaultHeight: 800,
+  });
+
+  // windowState must be serialized to be compatible with
+  // @trodi/electron-splashscreen
+  const windowStateObj = JSON.parse(JSON.stringify(windowState));
+
   window = initSplashScreen({
     templateUrl: path.join(__dirname, `splash-screen`, `index.html`),
-    splashScreenOpts: size,
+    splashScreenOpts: windowStateObj,
     windowOpts: Object.assign(
       {
         webPreferences: {
@@ -26,10 +35,12 @@ const createWindow = () => {
           preload: path.join(__dirname, `content.js`),
         },
       },
-      size
+      windowStateObj
     ),
   });
   window.setMenuBarVisibility(false);
+
+  windowState.manage(window);
 
   isDev && window.webContents.openDevTools();
   window.loadURL(POCKET_CASTS_URL);

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,6 +939,14 @@ electron-reloader@^0.2.0:
     chokidar "^2.0.0"
     electron-is-dev "^0.3.0"
 
+electron-window-state@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/electron-window-state/-/electron-window-state-5.0.3.tgz#4f36d09e3f953d87aff103bf010f460056050aa8"
+  integrity sha512-1mNTwCfkolXl3kMf50yW3vE2lZj0y92P/HYWFBrb+v2S/pCka5mdwN3cagKm458A7NjndSwijynXgcLWRodsVg==
+  dependencies:
+    jsonfile "^4.0.0"
+    mkdirp "^0.5.1"
+
 electron@^3.0.13:
   version "3.0.13"
   resolved "https://registry.yarnpkg.com/electron/-/electron-3.0.13.tgz#7b065a3d130c6b6379dc78d49515e03f392c1303"


### PR DESCRIPTION
Fixes #3 

> Note: In some desktop environments and themes, the title bar height is not factored in when setting the window's x/y coordinates. As a result, the window will be opened one title bar height lower each time it is opened. This is something that has to be fixed in electron core and AFAIK there's workaround or fix. This is occurring even in popular apps such as Discord and Spotify, so I hope that it will be fixed soon.